### PR TITLE
Fixed bugs in resource provider

### DIFF
--- a/providers/account.rb
+++ b/providers/account.rb
@@ -24,7 +24,7 @@ def load_current_resource
     "#{node['user']['home_root']}/#{new_resource.username}"
   @my_shell = new_resource.shell || node['user']['default_shell']
   @manage_home = bool(new_resource.manage_home, node['user']['manage_home'])
-  @create_group = bool(new_resource.manage_home, node['user']['create_group'])
+  @create_group = bool(new_resource.create_group, node['user']['create_group'])
   @ssh_keygen = bool(new_resource.ssh_keygen, node['user']['ssh_keygen'])
 end
 
@@ -36,10 +36,10 @@ action :create do
 end
 
 action :remove do
-  user_resource             :remove
   keygen_resource           :delete
   authorized_keys_resource  :delete
   dir_resource              :delete
+  user_resource             :remove  
 end
 
 action :modify do
@@ -154,10 +154,12 @@ def keygen_resource(exec_action)
   end
   e.run_action(:run) if @ssh_keygen && exec_action == :create
 
-  ["#{@my_home}/.ssh/id_dsa", "#{@my_home}/.ssh/id_dsa.pub"].each do |keyfile|
-    f = file keyfile do
-      backup  false
+  if exec_action == :delete then
+    ["#{@my_home}/.ssh/id_dsa", "#{@my_home}/.ssh/id_dsa.pub"].each do |keyfile|
+      file keyfile do
+        backup  false
+        action :delete
+      end
     end
-    f.run_action(exec_action) if exec_action == :delete
   end
 end


### PR DESCRIPTION
I started looking into the reason why even though ssh_keygen was set to false, the create action was still creating empty id_dsa and id_dsa.pub empty files (hence the name of the branch). Then I also found other bugs, but I am too lazy to create separate branches for each of them. :)

Change List:
- @create_group was read from new_resource.manage_home rather than new_resource.create_group
  - changed order of resource handling in action :remove to have the user being removed last (otherwise action delete on authorized_keys resource was failing because there was no user with the given name)
  - changed handling of id_dsa files so that they are not created unless necessary

I tested the code with both ssh_keygen true and false, and for create and remove actions.
