### PR TITLE
Provide default value for users array

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,3 +40,5 @@ default['user']['ssh_keygen']         = "true"
 
 default['user']['data_bag_name']        = "users"
 default['user']['user_array_node_attr'] = "users"
+
+default[default['user']['user_array_node_attr']] = []


### PR DESCRIPTION
In Chef 10.14.4, if no default value is provided, the following compile error occurs:
# 
# Recipe Compile Error in /tmp/chef-solo/cookbooks/user/recipes/data_bag.rb
## ArgumentError

```
Attribute to_ary is not defined!
```
## Cookbook Trace:

```
  /tmp/chef-solo/cookbooks/user/recipes/data_bag.rb:32:in `Array'
  /tmp/chef-solo/cookbooks/user/recipes/data_bag.rb:32:in `from_file'
```
## Relevant File Content:

/tmp/chef-solo/cookbooks/user/recipes/data_bag.rb:

```
 25:  #     node['user']['user_array_node_attr'] = "base/user_accounts"
 26:  user_array = node
 27:  node['user']['user_array_node_attr'].split("/").each do |hash_key|
 28:    user_array = user_array.send(:[], hash_key)
 29:  end
 30:
 31:  # only manage the subset of users defined
 32>> Array(user_array).each do |i|
 33:    u = data_bag_item(bag, i.gsub(/[.]/, '-'))
 34:    username = u['username'] || u['id']
 35:
 36:    user_account username do
 37:      %w{comment uid gid home shell password system_user manage_home create_group
 38:          ssh_keys ssh_keygen}.each do |attr|
 39:        send(attr, u[attr]) if u[attr]
 40:      end
 41:      action u['action'].to_sym if u['action']
```
