### PR TITLE
Automated SSH Public Key Distribution within a Cluster

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,8 @@ end
 default['user']['manage_home']        = "true"
 default['user']['create_user_group']  = "true"
 default['user']['ssh_keygen']         = "true"
+default['user']['ssh_store_key']      = "true"
+default['user']['ssh_pull_key']       = "true"
 
 default['user']['data_bag_name']        = "users"
 default['user']['user_array_node_attr'] = "users"

--- a/resources/account.rb
+++ b/resources/account.rb
@@ -33,6 +33,8 @@ attribute :manage_home,   :default => nil
 attribute :create_group,  :default => nil
 attribute :ssh_keys,      :kind_of => [Array,String], :default => []
 attribute :ssh_keygen,    :default => nil
+attribute :ssh_store_key, :default => nil
+attribute :ssh_pull_key,  :default => nil
 
 def initialize(*args)
   super


### PR DESCRIPTION
Added the ability to automatically distribute public keys within a cluster.

For every user that is created using the user_resource on a node that has attributes:
    cluster { name : "ClusterName", role : "master" }

    The public key will be distributed to every node that has attributes:
        cluster { name : "ClusterName", role : "slave" }

Example:

user_account 'comaccount' do
  comment       'Communications Account'
  ssh_keygen    true
  ssh_store_key true
  ssh_pull_key  true
  home          '/home/comaccount'
  manage_home   true
end

By including this in your recipe and than setting appropriate cluster attributes will make it so the comaccount on master can always communicate via ssh using keys to all of its slaves.