### PR TITLE
Allow plaintext password to be used

### DIFF
--- a/providers/account.rb
+++ b/providers/account.rb
@@ -24,9 +24,9 @@ def load_current_resource
     "#{node['user']['home_root']}/#{new_resource.username}"
   @my_shell = new_resource.shell || node['user']['default_shell']
   @my_password = if bool(new_resource.use_plaintext, node['user']['use_plaintext'])
-    generate_hash_from_plaintext(new_resource.password)
+    generate_hash_from_plaintext(new_resource.password || node['user']['password'])
   else
-    new_resource.password
+    new_resource.password || node['user']['password']
   end
   @manage_home = bool(new_resource.manage_home, node['user']['manage_home'])
   @create_group = bool(new_resource.create_group, node['user']['create_group'])

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -33,19 +33,8 @@ Array(user_array).each do |i|
   u = data_bag_item(bag, i.gsub(/[.]/, '-'))
   username = u['username'] || u['id']
 
-  def generate_shadowhash(plaintext_pass)
-    require 'digest/sha2'
-    salt = rand(36**8).to_s(36)
-    shadow_hash = plaintext_pass.crypt("$6$" + salt)
-    return shadow_hash
-  end
-
-  if u['plaintext_password']
-    u['password'] = generate_shadowhash u['password']
-  end
-
   user_account username do
-    %w{comment uid gid home shell password system_user manage_home create_group
+    %w{comment uid gid home shell password use_plaintext system_user manage_home create_group
         ssh_keys ssh_keygen}.each do |attr|
       send(attr, u[attr]) if u[attr]
     end

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -33,6 +33,17 @@ Array(user_array).each do |i|
   u = data_bag_item(bag, i.gsub(/[.]/, '-'))
   username = u['username'] || u['id']
 
+  def generate_shadowhash(plaintext_pass)
+    require 'digest/sha2'
+    salt = rand(36**8).to_s(36)
+    shadow_hash = plaintext_pass.crypt("$6$" + salt)
+    return shadow_hash
+  end
+
+  if u['plaintext_password']
+    u['password'] = generate_shadowhash u['password']
+  end
+
   user_account username do
     %w{comment uid gid home shell password system_user manage_home create_group
         ssh_keys ssh_keygen}.each do |attr|

--- a/resources/account.rb
+++ b/resources/account.rb
@@ -28,6 +28,7 @@ attribute :gid,           :kind_of => [String,Integer]
 attribute :home,          :kind_of => String
 attribute :shell,         :kind_of => String
 attribute :password,      :kind_of => String
+attribute :use_plaintext, :default => nil
 attribute :system_user,   :default => false
 attribute :manage_home,   :default => nil
 attribute :create_group,  :default => nil


### PR DESCRIPTION
Databag encryption is dealt with elsewhere, so it seems alright that some folks might not care that the non-shadowhashed password is used from the databag.

Thinking maybe we could check:
- whether a `shadowhash_password` LRWP attribute is set
- if set to false (and so assume plaintext), use this method to generate: http://judepereira.com/blog/use-ruby-to-generate-your-shadow-password/

Would regenerate each time chef runs, but don't think that would be an issue?

I'll try to test it out