### PR TITLE
Create distinct initial login group for each user account created

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ data bag called `"users"` with an item like the following:
       "id"        : "hsolo",
       "comment"   : "Han Solo",
       "home"      : "/opt/hoth/hsolo",
+      "uid"       : 501,
+      "gid"       : 501,
       "ssh_keys"  : ["123...", "456..."]
     }
 

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -29,6 +29,7 @@ def load_current_resource
 end
 
 action :create do
+  group_resource            :create
   user_resource             :create
   dir_resource              :create
   authorized_keys_resource  :create
@@ -85,6 +86,18 @@ def normalize_bool(val)
   when 'no','false',false then false
   else true
   end
+end
+
+def group_resource(exec_action)
+  # avoid variable scoping issues in resource block
+
+  r = group new_resource.username do
+    group_name new_resource.username if new_resource.username
+    gid        new_resource.gid      if new_resource.gid
+    action    :nothing
+  end
+  r.run_action(:create) if @create_group && exec_action == :create
+  new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 end
 
 def user_resource(exec_action)


### PR DESCRIPTION
This change implements the adduser behavior when using the -U, --user-group flag:
- If a user account is added, a group of the same name will be added.
- The group gid will be taken from the data_bag item.

As your cookbook is implemented, a gid can only be used in a data_bag item if it already exists in /etc/group. I couldn't see how to create a group using your recipes (I may just be dumb, though).

With my change, your cookbook create a distinct initial login group for each user account that it creates. In fact, the gid must not exist if the uid does not exist -- this is bad for folks doing something like a wheel group for all sysadmin users. An attempt to reuse a gid or to not supply one leads to failure.

It would be wonderful if you could generalize this somehow.  I realize that my change won't support every use case, so you may not want to use my change directly. In system builds such as ours, an application installation user account is always in a default group of the same name. E.g., apache:apache, tomcat:tomcat, postgres:postgres, etc.

Thanks for a very useful cookbook,
David Crane
davidc@donorschoose.org
