### PR TITLE
Management of groups is integrated and consistent with management of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ this by installing the "libshadow-ruby1.8" package.
       <td><code>nil</code></td>
     </tr>
     <tr>
+      <td>groups</td>
+      <td>Supplimentary groups, if any, listed by groupname.</td>
+      <td><code>nil</code></td>
+    </tr>
+    <tr>
       <td>home</td>
       <td>Home directory location.</td>
       <td><code>"#{node['user']['home_root']}/#{username}</code></td>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ data bag called `"users"` with an item like the following:
       "home"      : "/opt/hoth/hsolo",
       "uid"       : 501,
       "gid"       : 501,
+      "groups"    : ["rebel","smuggler"], // Optional supplementary groups
       "ssh_keys"  : ["123...", "456..."]
     }
 
@@ -30,6 +31,19 @@ or a user to be removed:
     {
       "id"      : "lando",
       "action"  : "remove"
+    }
+
+The login and supplementary groups for this user can be created within a
+data bag called `"groups"` with items such as the following:
+  
+    {
+      "id"        : "hsolo",
+      "gid"       : 501
+    }
+  
+    {
+      "id"        : "rebel",
+      "gid"       : 1138
     }
 
 The data bag recipe will iterate through a list of usernames defined in
@@ -200,6 +214,22 @@ For example, if the users' array is stored in `node['system']['accounts']`),
 then set `node['user']['user_array_node_attr']` to `"system/accounts"`.
 
 The default is `"users"`.
+
+### <a name="attributes-group-data-bag-name"></a> group_data_bag_name
+
+The data bag name containing a group of user groups information. This is used
+by the `data_bag` recipe to use as a database of user groups.
+
+The default is `"groups"`.
+
+### <a name="attributes-group-array-node-attr"></a> group_array_node_attr
+
+The node attributes containing an array of groups to be managed. If a nested
+hash in the node's attributes is required, then use a `/` between subhashes.
+For example, if the groups' array is stored in `node['system']['groups']`),
+then set `node['user']['group_array_node_attr']` to `"system/groups"`.
+
+The default is `"groups"`.
 
 ## <a name="lwrps"></a> Resources and Providers
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ data bag called `"users"` with an item like the following:
       "id"        : "hsolo",
       "comment"   : "Han Solo",
       "home"      : "/opt/hoth/hsolo",
+      "uid"       : 501,
+      "gid"       : 501,
       "ssh_keys"  : ["123...", "456..."]
     }
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,3 +40,6 @@ default['user']['ssh_keygen']         = "true"
 
 default['user']['data_bag_name']        = "users"
 default['user']['user_array_node_attr'] = "users"
+
+default['user']['group_data_bag_name']   = "groups"
+default['user']['group_array_node_attr'] = "groups"

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -29,7 +29,6 @@ def load_current_resource
 end
 
 action :create do
-  group_resource            :create
   user_resource             :create
   dir_resource              :create
   authorized_keys_resource  :create
@@ -37,9 +36,8 @@ action :create do
 end
 
 action :remove do
-  keygen_resource           :delete
-  authorized_keys_resource  :delete
-  dir_resource              :delete
+  # Removing a user will also remove all the other file based resources.
+  # By only removing the user it will make this action idempotent.
   user_resource             :remove
 end
 

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -29,6 +29,7 @@ def load_current_resource
 end
 
 action :create do
+  group_resource            :create
   user_resource             :create
   dir_resource              :create
   authorized_keys_resource  :create
@@ -85,6 +86,18 @@ def normalize_bool(val)
   when 'no','false',false then false
   else true
   end
+end
+
+def group_resource(exec_action)
+  # avoid variable scoping issues in resource block
+
+  r = group new_resource.username do
+    group_name new_resource.username if new_resource.username
+    gid        new_resource.gid      if new_resource.gid
+    action    :nothing
+  end
+  r.run_action(:create) if @create_group && exec_action == :create
+  new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 end
 
 def user_resource(exec_action)

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -17,12 +17,49 @@
 # limitations under the License.
 #
 
+# Look for user definitions in data_bags/[BAG]/*.json
+# and group definitions in data_bags/[BAG]/*.json,
+# where [BAG] is named in this node attribute.
+# (default group_bag = 'users')
+group_bag = node['user']['group_data_bag_name']
+
+# Fetch the group array from the node's attribute hash. If a subhash is
+# desired (ex. node['base']['user_groups']), then set:
+#
+#     node['user']['group_array_node_attr'] = "base/user_groups"
+# (default group_array = 'groups')
+group_array = node
+node['user']['group_array_node_attr'].split("/").each do |hash_key|
+  group_array = group_array.send(:[], hash_key)
+end
+
+# only manage the subset of groups defined
+Array(group_array).each do |i|
+  g = data_bag_item(group_bag, i.gsub(/[.]/, '-'))
+  groupname = g['groupname'] || g['id']
+
+  # Don't remove groups yet, since we may need to remove users first.
+  if (g['action'].nil? || (g['action'] != 'remove'))
+    group groupname do
+      %w{gid}.each do |attr|
+        send(attr, g[attr]) if g[attr]
+      end          
+      action g['action'].to_sym if g['action']
+    end
+  end
+end
+
+# Look for user definitions in data_bags/[BAG]/*.json
+# and group definitions in data_bags/[BAG]/groups/*.json,
+# where [BAG] is named in this node attribute.
+# (default bag = 'users')
 bag = node['user']['data_bag_name']
 
 # Fetch the user array from the node's attribute hash. If a subhash is
 # desired (ex. node['base']['user_accounts']), then set:
 #
 #     node['user']['user_array_node_attr'] = "base/user_accounts"
+# (default user_array = 'users')
 user_array = node
 node['user']['user_array_node_attr'].split("/").each do |hash_key|
   user_array = user_array.send(:[], hash_key)
@@ -41,12 +78,32 @@ Array(user_array).each do |i|
     action u['action'].to_sym if u['action']
   end
 
-  unless u['groups'].nil?
-    u['groups'].each do |groupname|
-      group groupname do
-        members username
-        append true
+  # Don't try to add user to groups if we are removing user
+  if (u['action'].nil? || (u['action'] != 'remove'))
+    unless u['groups'].nil?
+      u['groups'].each do |groupname|
+        group groupname do
+          members username
+          append true
+        end
       end
     end
   end
 end
+
+# Now try to remove groups (since users would now have been removed)
+# only manage the subset of groups defined
+Array(group_array).each do |i|
+  g = data_bag_item(group_bag, i.gsub(/[.]/, '-'))
+  groupname = g['groupname'] || g['id']
+
+  unless (g['action'].nil? || (g['action'] != 'remove'))
+    group groupname do
+      %w{gid}.each do |attr|
+        send(attr, g[attr]) if g[attr]
+      end          
+      action g['action'].to_sym if g['action']
+    end
+  end
+end
+


### PR DESCRIPTION
Define "groups" in your data_bags and listed by groupname as your node attribute. Those define which groups will be managed if you include_recipe "user::data_bag". This is the same algorithm used to manage "users".

The ordering of the "create" and "remove" operations for users and groups is carefully controlled to avoid failures. If your data_bags change the supplimentary "groups" attributes for a user account, these will be modified in the system by the next chef run. 

One design issue: Regardless of what "users" or "groups" are listed in node attributes to be managed, any user or group defined in the data_bags specified with the "remove" action will be removed from the system by the recipe[user::data_bags]. I reasoned that this is probably expected behavior and it didn't seem worthwhile to add to the complexity of node attributes with specific lists. Someone may want to modify the interface with "remove_users" and "remove_groups" lists in the node attributes, which would be symmetric with the "users" and "groups" lists for management. I felt the most likely use case was to remove user accounts across the entire infrastructure. One simple change to mark the item in the data_bags with "action" : "remove" will propagate that change across all systems as chef is run. The need to hunt down all node attributes seems burdensome. Still, the "remove_*" lists might be convenient for changes like migrating applications between systems so that an application account could be retired on the old system.

Slight problems (I believe these were already issues before my changes):
- Changes to a login "gid" attribute in the "users" data_bags will not be changed in the system if chef has already created the user account. 
- The login group must be explicitly created; that is, the "create_group" attribute in the "users" data_bags doesn't seem to have any effect. I must specify a "gid" in each of the the "users" and I must create the group -- which can now be managed in the "groups" data_bags. However, I _can_ specify any gid for the login group.
