### PR TITLE
Add groups attribute to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ this by installing the "libshadow-ruby1.8" package.
       <td><code>nil</code></td>
     </tr>
     <tr>
+      <td>groups</td>
+      <td>Array of other groups this user should be a member of.</td>
+      <td><code>nil</code></td>
+    </tr>
+    <tr>
       <td>home</td>
       <td>Home directory location.</td>
       <td><code>"#{node['user']['home_root']}/#{username}</code></td>


### PR DESCRIPTION
The code seems to be allowing you to set groups here: https://github.com/fnichol/chef-user/blob/master/recipes/data_bag.rb#L44 but it isn't in the list in the README.md file.