### PR TITLE
Don't make group resources for those already added

### DIFF
--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -28,6 +28,8 @@ node['user']['user_array_node_attr'].split("/").each do |hash_key|
   user_array = user_array.send(:[], hash_key)
 end
 
+groups = {}
+
 # only manage the subset of users defined
 Array(user_array).each do |i|
   u = data_bag_item(bag, i.gsub(/[.]/, '-'))
@@ -43,10 +45,15 @@ Array(user_array).each do |i|
 
   unless u['groups'].nil? || u['action'] == 'remove'
     u['groups'].each do |groupname|
-      group groupname do
-        members username
-        append true
-      end
+      groups[groupname] = [] unless groups[groupname]
+      groups[groupname] += [username]
     end
+  end
+end
+
+groups.each do |groupname, users|
+  group groupname do
+    members users
+    append true
   end
 end


### PR DESCRIPTION
@claco has pushed a PR which addresses excessive resource cloning in the data_bag recipe. This PR takes that one step further, by not only eliminating group resource cloning, but also reducing the number of resource declarations. Previously, there was one group resource per group per user. Now, we'll club all the users into a hash and create each group just once.

This cut down the number of resources in our chef run by nearly 100.

Related PR:
https://github.com/fnichol/chef-user/pull/49
