### PR TITLE
Data bag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ this by installing the "libshadow-ruby1.8" package.
         A <b>String</b> or <b>Array</b> of SSH public keys to populate the
         user's <code>.ssh/authorized_keys</code> file.
         If the provided String is not a vaild ssh public-key, it will try to retrieve
-        the public-key from the data_bag specified in <code>data_bag</code> (see below)
+        the public-key from the data_bag specified in <code>ssh_pubkey_data_bag</code> (see below)
       </td>
       <td><code>[]</code></td>
     </tr>
@@ -388,7 +388,7 @@ this by installing the "libshadow-ruby1.8" package.
       <td><code>[]</code></td>
     </tr>
     <tr>
-      <td>data_bag</td>
+      <td>ssh_pubkey_data_bag</td>
       <td>
         A <b>String</b> providing the name of the data_bag holding the public keys.
         Expected format of the data_bag:

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ this by installing the "libshadow-ruby1.8" package.
       <td>
         A <b>String</b> or <b>Array</b> of SSH public keys to populate the
         user's <code>.ssh/authorized_keys</code> file.
+        If the provided String is not a vaild ssh public-key, it will try to retrieve
+        the public-key from the data_bag specified in <code>data_bag</code> (see below)
       </td>
       <td><code>[]</code></td>
     </tr>
@@ -384,6 +386,23 @@ this by installing the "libshadow-ruby1.8" package.
       <td>groups</td>
       <td>An Array of groups to which to add the user.</td>
       <td><code>[]</code></td>
+    </tr>
+    <tr>
+      <td>data_bag</td>
+      <td>
+        A <b>String</b> providing the name of the data_bag holding the public keys.
+        Expected format of the data_bag:
+        <pre>
+{
+  "id": "username",
+  "keys": [
+    "ssh-ed25519 AAAA...",
+    "ssh-rsa AAAA..."
+  ]
+}
+        </pre>
+      </td>
+      <td><code>'ssh_public_keys'</code></td>
     </tr>
   </tbody>
 </table>

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -198,8 +198,11 @@ def authorized_keys_resource(exec_action)
   # avoid variable scoping issues in resource block
   ssh_keys = []
   Array(new_resource.ssh_keys).each do |item|
-    # if item is a valid ssh key, copy it.
-    if item =~ /^(ssh-(dss|rsa|ed25519)|ecdsa-sha2-\w+) AAAA/
+    # Check whether the data bag item is a comment or a valid ssh public key label.
+    #
+    # Note: This regex is kept pretty tolerant to allow notations like this:
+    #       `environment="SSH_USER=user" ssh-rsa AAAA...`
+    if item =~ /(^\s*#|ssh-(dss|rsa|ed25519)|ecdsa-sha2-\w+ AAAA)/
       ssh_keys << item
 
     # if key is not a valid ssh public key, assume it's a username

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -209,7 +209,7 @@ def authorized_keys_resource(exec_action)
       if user['keys']
         ssh_keys += Array(user['keys'])
       else
-        Chef::Log.info("Couldn't get ssh public keys from data bag '#{new_resource.ssh_pubkey_data_bag}' for user '#{item}'")
+        Chef::Log.warn("Couldn't get ssh public keys from data bag '#{new_resource.ssh_pubkey_data_bag}' for user '#{item}'")
       end
     end
   end

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -205,11 +205,11 @@ def authorized_keys_resource(exec_action)
     # if key is not a valid ssh public key, assume it's a username
     # and try getting the ssh keys from the data bag
     else
-      user = data_bag_item(new_resource.data_bag, item)
+      user = data_bag_item(new_resource.ssh_pubkey_data_bag, item)
       if user['keys']
         ssh_keys += Array(user['keys'])
       else
-        Chef::Log.info("Couldn't get ssh public keys from data bag '#{new_resource.data_bag}' for user '#{item}'")
+        Chef::Log.info("Couldn't get ssh public keys from data bag '#{new_resource.ssh_pubkey_data_bag}' for user '#{item}'")
       end
     end
   end

--- a/resources/account.rb
+++ b/resources/account.rb
@@ -36,6 +36,7 @@ attribute :ssh_keys,      :kind_of => [Array,String], :default => []
 attribute :groups,        :kind_of => [Array,String], :default => []
 attribute :ssh_keygen,    :default => nil
 attribute :ssh_keypair,   :kind_of => Hash, :default => {}
+attribute :data_bag,      :kind_of => String, :default => 'ssh_public_keys'
 
 def initialize(*args)
   super

--- a/resources/account.rb
+++ b/resources/account.rb
@@ -21,22 +21,22 @@
 
 actions :create, :remove, :modify, :manage, :lock, :unlock
 
-attribute :username,      :kind_of => String, :name_attribute => true
-attribute :comment,       :kind_of => String
-attribute :uid,           :kind_of => [String,Integer]
-attribute :gid,           :kind_of => [String,Integer]
-attribute :home,          :kind_of => String
-attribute :shell,         :kind_of => String
-attribute :password,      :kind_of => String
-attribute :system_user,   :default => false
-attribute :manage_home,   :default => nil
-attribute :non_unique,    :default => nil
-attribute :create_group,  :default => nil
-attribute :ssh_keys,      :kind_of => [Array,String], :default => []
-attribute :groups,        :kind_of => [Array,String], :default => []
-attribute :ssh_keygen,    :default => nil
-attribute :ssh_keypair,   :kind_of => Hash, :default => {}
-attribute :data_bag,      :kind_of => String, :default => 'ssh_public_keys'
+attribute :username,            :kind_of => String, :name_attribute => true
+attribute :comment,             :kind_of => String
+attribute :uid,                 :kind_of => [String,Integer]
+attribute :gid,                 :kind_of => [String,Integer]
+attribute :home,                :kind_of => String
+attribute :shell,               :kind_of => String
+attribute :password,            :kind_of => String
+attribute :system_user,         :default => false
+attribute :manage_home,         :default => nil
+attribute :non_unique,          :default => nil
+attribute :create_group,        :default => nil
+attribute :ssh_keys,            :kind_of => [Array,String], :default => []
+attribute :groups,              :kind_of => [Array,String], :default => []
+attribute :ssh_keygen,          :default => nil
+attribute :ssh_keypair,         :kind_of => Hash, :default => {}
+attribute :ssh_pubkey_data_bag, :kind_of => String, :default => 'ssh_public_keys'
 
 def initialize(*args)
   super

--- a/test/cookbooks/user_test/recipes/lwrp.rb
+++ b/test/cookbooks/user_test/recipes/lwrp.rb
@@ -2,7 +2,7 @@ include_recipe 'user'
 
 user_account 'hsolo' do
   comment   'Han Solo'
-  ssh_keys  ['key111...', 'key222...']
+  ssh_keys  ['ssh-rsa AAAA111', 'ssh-ed25519 AAAA222']
   home      '/opt/hoth/hsolo'
 end
 

--- a/test/integration/data_bags/users/hsolo.json
+++ b/test/integration/data_bags/users/hsolo.json
@@ -3,5 +3,5 @@
   "comment"   : "Han Solo",
   "home"      : "/opt/hoth/hsolo",
   "groups"    : ["admin", "www-data"],
-  "ssh_keys"  : ["123...", "456..."]
+  "ssh_keys"  : ["ssh-rsa AAAA123", "ssh-ed25519 AAAA456"]
 }

--- a/test/integration/home_dir_mode/serverspec/default_spec.rb
+++ b/test/integration/home_dir_mode/serverspec/default_spec.rb
@@ -24,8 +24,8 @@ describe 'chef-user-test::default' do
     it { should be_directory }
   end
   describe file('/opt/hoth/hsolo/.ssh/authorized_keys') do
-    its(:content) { should match /key111\.\.\./ }
-    its(:content) { should match /key222\.\.\./ }
+    its(:content) { should match 'ssh-rsa AAAA111' }
+    its(:content) { should match 'ssh-ed25519 AAAA222' }
   end
 
 

--- a/test/integration/lwrp/serverspec/default_spec.rb
+++ b/test/integration/lwrp/serverspec/default_spec.rb
@@ -24,8 +24,8 @@ describe 'chef-user-test::default' do
     it { should be_directory }
   end
   describe file('/opt/hoth/hsolo/.ssh/authorized_keys') do
-    its(:content) { should match /key111\.\.\./ }
-    its(:content) { should match /key222\.\.\./ }
+    its(:content) { should match 'ssh-rsa AAAA111' }
+    its(:content) { should match 'ssh-ed25519 AAAA222' }
   end
 
 


### PR DESCRIPTION
I found it very useful to be able to retrieve users public keys from a central data dag, even when setting up users using the LWRP.

This pull requests adds support for not only specifying ssh keys in the `ssh_keys` attribute, but also transparently use data bag items, containing these keys. 

They can be used alongside each other, and the implementation shouldn't break any existing setups.

The following example will assign all three provided keys to the user

``` ruby
user_account 'chris' do
  home '/home/chris'
  ssh_keys [ 'ssh-rsa AAAA....' , 'chris' ]
  data_bag 'ssh_public_keys'
end
```

``` json
{
  "id": "chris",
  "keys": [
    "ssh-ed25519 AAAA...",
    "ssh-rsa AAAA..."
  ]
}
```
