### PR TITLE
Fix wrong action in account provider

### DIFF
--- a/providers/account.rb
+++ b/providers/account.rb
@@ -98,7 +98,7 @@ def user_resource(exec_action)
     recursive true
     action    :nothing
   end
-  r.run_action(:create) unless exec_action == :delete
+  r.run_action(:create) unless exec_action == :remove
   new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 
   r = user new_resource.username do


### PR DESCRIPTION
The `:delete` action should be `:remove`

With the current code, when deleting a user, the home directory is always created and then deleted again on each chef-run.
