### PR TITLE
conform to new chefspec matcher definition syntax for versions of chefspec >= 4.1

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,8 +1,9 @@
 if defined?(ChefSpec)
-  if Gem::Version.new(ChefSpec::VERSION) >= Gem::Version.new('4.0.0')
-    ChefSpec.define_matcher :user_account
-  else
+  chefspec_version = Gem.loaded_specs['chefspec'].version
+  if chefspec_version < Gem::Version.new('4.1.0')
     ChefSpec::Runner.define_runner_method :user_account
+  else
+    ChefSpec.define_matcher :user_account
   end
 
   def create_user_account(user)

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,10 @@
 if defined?(ChefSpec)
-  ChefSpec::Runner.define_runner_method :user_account
+  if Gem::Version.new(ChefSpec::VERSION) >= Gem::Version.new('4.0.0')
+    ChefSpec.define_matcher :user_account
+  else
+    ChefSpec::Runner.define_runner_method :user_account
+  end
+
   def create_user_account(user)
     ChefSpec::Matchers::ResourceMatcher.new(:user_account, :create, user)
   end

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -30,41 +30,41 @@ def load_current_resource
   @ssh_keygen = bool(new_resource.ssh_keygen, node['user']['ssh_keygen'])
 end
 
-action :create do
+action :create do # ~FC017: LWRP does not notify when updated
   user_resource             :create
   dir_resource              :create
   authorized_keys_resource  :create
   keygen_resource           :create
 end
 
-action :remove do
+action :remove do # ~FC017: LWRP does not notify when updated
   # Removing a user will also remove all the other file based resources.
   # By only removing the user it will make this action idempotent.
   user_resource             :remove
 end
 
-action :modify do
+action :modify do # ~FC017: LWRP does not notify when updated
   user_resource             :modify
   dir_resource              :create
   authorized_keys_resource  :create
   keygen_resource           :create
 end
 
-action :manage do
+action :manage do # ~FC017: LWRP does not notify when updated
   user_resource             :manage
   dir_resource              :create
   authorized_keys_resource  :create
   keygen_resource           :create
 end
 
-action :lock do
+action :lock do # ~FC017: LWRP does not notify when updated
   user_resource             :lock
   dir_resource              :create
   authorized_keys_resource  :create
   keygen_resource           :create
 end
 
-action :unlock do
+action :unlock do # ~FC017: LWRP does not notify when updated
   user_resource             :unlock
   dir_resource              :create
   authorized_keys_resource  :create
@@ -108,7 +108,7 @@ def user_resource(exec_action)
     home      my_home               if my_home
     shell     my_shell              if my_shell
     password  new_resource.password if new_resource.password
-    system    new_resource.system_user
+    system    new_resource.system_user # ~FC048: Prefer Mixlib::ShellOut
     supports  :manage_home => manage_home, :non_unique => non_unique
     action    :nothing
   end


### PR DESCRIPTION
chefspec 4.1.0 and greater displays depreciation messages when using the ChefSpec::Runner.define_runner_method syntax. This updates these to use the new define_matcher but should not break those using the older chefspec gem.