### PR TITLE
Revert "Provide default value for users array"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,5 +46,3 @@ default['user']['non_unique']         = "false"
 
 default['user']['data_bag_name']        = "users"
 default['user']['user_array_node_attr'] = "users"
-
-default[default['user']['user_array_node_attr']] = []


### PR DESCRIPTION
Hi,

This was included in 0.4.\* recent release, unfortunately this commit breaks metachef cookbook

```
==> default: [2015-03-23T15:04:29+00:00] DEBUG: Node assembla loading cookbook metachef's attribute file /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb
==> default: [2015-03-23T15:04:29+00:00] DEBUG: Loading Attribute metachef::default
==> default: [2015-03-23T15:04:29+00:00] DEBUG: filtered backtrace of compile error: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `[]',/tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `from_file'
==> default: [2015-03-23T15:04:29+00:00] DEBUG: filtered backtrace of compile error: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `[]',/tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `from_file'
==> default: [2015-03-23T15:04:29+00:00] DEBUG: backtrace entry for compile error: '/tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `[]''
==> default: [2015-03-23T15:04:29+00:00] DEBUG: Line number of compile error: '9'
==> default: 
==> default: ================================================================================
==> default: Recipe Compile Error in /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb
==> default: ================================================================================
==> default: 
==> default: 
==> default: TypeError
==> default: ---------
==> default: can't convert String into Integer
==> default: 
==> default: Cookbook Trace:
==> default: ---------------
==> default:   /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `[]'
==> default:   /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `from_file'
==> default: 
==> default: 
==> default: Relevant File Content:
==> default: ----------------------
==> default: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:
==> default: 
==> default: 
==> default:   2:  default[:metachef][:conf_dir] = '/etc/metachef'
==> default:   3:  default[:metachef][:log_dir]  = '/var/log/metachef'
==> default:   4:  default[:metachef][:home_dir] = '/etc/metachef'
==> default:   5:  
==> default:   6:  default[:metachef][:user]     = 'root'
==> default:   7:  
==> default: 
==> default:   8:  # Request user account properties here.
==> default:   9>> default[:users]['root'][:primary_group] = value_for_platform(
==> default:  10:    "openbsd"   => { "default" => "wheel" },
==> default: 
==> default:  11:    "freebsd"   => { "default" => "wheel" },
==> default:  12:    "mac_os_x"  => { "default" => "wheel" },
==> default:  13:    "default"   => "root"
==> default:  14:  )
==> default:  15:  
==> default:  16:  default[:announces] ||= Mash.new
==> default:  17:  
==> default:  18:  default[:discovers] ||= Mash.new
==> default: 
==> default: [2015-03-23T15:04:29+00:00] DEBUG: Re-raising exception: TypeError - can't convert String into Integer
==> default: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `[]'
==> default:   /tmp/vagrant-chef-3/chef-solo-1/cookbooks/metachef/attributes/default.rb:9:in `from_file'
```
