### PR TITLE
(bug) Dont create ssh_keys if keygen attribute is set to nil

### DIFF
--- a/providers/account.rb
+++ b/providers/account.rb
@@ -89,7 +89,7 @@ end
 
 def normalize_bool(val)
   case val
-  when 'no','false',false then false
+  when nil, 'no', 'false', false then false
   else true
   end
 end


### PR DESCRIPTION
Treat nil as false
