### PR TITLE
Add keychain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,9 +393,11 @@ this by installing the "libshadow-ruby1.8" package.
 ##### Creating a User Account
 
     user_account 'hsolo' do
-      comment   'Han Solo'
-      ssh_keys  ['3dc348d9af8027df7b9c...', '2154d3734d609eb5c452...']
-      home      '/opt/hoth/hsolo'
+      comment     'Han Solo'
+      ssh_keys    ['3dc348d9af8027df7b9c...', '2154d3734d609eb5c452...']
+      home        '/opt/hoth/hsolo'
+      ssh_keypair 'id_rsa' => "-----BEGIN OPENSSH PRIVATE KEY-----\n...",
+                  'id_rsa.pub' => 'ssh-rsa AAAA....'
     end
 
 ##### Creating and Locking a User Account

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -27,8 +27,7 @@ def whyrun_supported?
 end
 
 def load_current_resource
-  @my_home = new_resource.home ||
-    "#{node['user']['home_root']}/#{new_resource.username}"
+  @my_home = user_home
   @my_shell = new_resource.shell || node['user']['default_shell']
   @manage_home = bool(new_resource.manage_home, node['user']['manage_home'])
   @non_unique = bool(new_resource.non_unique, node['user']['non_unique'])

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -109,6 +109,15 @@ rescue ArgumentError
   nil
 end
 
+def user_home
+  # this check is needed as the new user won't exit yet
+  # in why_run mode, causing an uncaught ArgumentError exception
+  new_resource.home || Etc.getpwnam(new_resource.username).dir
+rescue ArgumentError
+  nil
+end
+
+
 def user_resource(exec_action)
   # avoid variable scoping issues in resource block
   my_home, my_shell, manage_home, non_unique = @my_home, @my_shell, @manage_home, @non_unique

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -247,7 +247,7 @@ def keypair_resource(exec_action)
     key_name, key_content = name, key
 
     home = Etc.getpwnam(new_resource.username).dir
-    r = file "#{home}/.ssh/#{name}" do
+    r = file ::File.join(home, '.ssh', name) do
       content   key_content + "\n"
       owner     new_resource.username
       group     Etc.getpwnam(new_resource.username).gid

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -255,11 +255,12 @@ def keypair_resource(exec_action)
     # avoid variable scoping issues in resource block
     key_name, key_content = name, key
 
-    home = Etc.getpwnam(new_resource.username).dir
+    home = user_home
+    resource_gid = user_gid
     r = file ::File.join(home, '.ssh', name) do
       content   key_content + "\n"
       owner     new_resource.username
-      group     Etc.getpwnam(new_resource.username).gid
+      group     resource_gid
       mode      '0600' unless key_name =~ /.pub$/
       sensitive true
       action    :nothing

--- a/resources/account.rb
+++ b/resources/account.rb
@@ -35,6 +35,7 @@ attribute :create_group,  :default => nil
 attribute :ssh_keys,      :kind_of => [Array,String], :default => []
 attribute :groups,        :kind_of => [Array,String], :default => []
 attribute :ssh_keygen,    :default => nil
+attribute :ssh_keypair,   :kind_of => Hash, :default => {}
 
 def initialize(*args)
   super


### PR DESCRIPTION
Allows a keychain hash to be specified, containing an ssh keypair which
will be deployed to the users homedir.
