### PR TITLE
bump version string to 0.5.0 to prep for release

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fnichol@nichol.ca'
 license          'Apache 2.0'
 description      'A convenient Chef LWRP to manage user accounts and SSH keys (this is not the opscode users cookbook)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.2'
+version          '0.5.0'
 
 issues_url 'https://github.com/fnichol/chef-user/issues'
 source_url 'https://github.com/fnichol'


### PR DESCRIPTION
This project has been dormant for awhile, and I wanted to have a nice
recap of things introduced since `0.4.2` was released:

* fix an error in the LWRP when a `--why-run` invocation is invoked
  before the user has been created (PR #89 by Tim Heckman).
* add a `groups` resource to the LWRP to allow the user to be added to
  additional groups upon creation (PR #96 by acqant)
* add `issues_url` and `source_url` to the metadata file
* fix tests and dependencies to work with Ruby 2.1.4 (version shipped
  with Chef 12.1.0)