### PR TITLE
[metadata] fix an error with the source_url; v0.5.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email 'fnichol@nichol.ca'
 license          'Apache 2.0'
 description      'A convenient Chef LWRP to manage user accounts and SSH keys (this is not the opscode users cookbook)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.5.0'
+version          '0.5.1'
 
 issues_url 'https://github.com/fnichol/chef-user/issues'
-source_url 'https://github.com/fnichol'
+source_url 'https://github.com/fnichol/chef-user'
 
 supports 'ubuntu'
 supports 'debian'


### PR DESCRIPTION
I had a very embarrassing error in the `source_url` key. Somehow the
name of the repo was trimmed off and it was sending people to Fletcher's
GitHub page.

This does not include a functional change of the cookbook or LWRP.