### PR TITLE
Fix Chef 13 issues

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-case platform
+case node['platform']
 when 'debian','ubuntu','redhat','centos','amazon','scientific','fedora','freebsd','suse'
   default['user']['home_root']      = "/home"
   default['user']['default_shell']  = "/bin/bash"

--- a/providers/account.rb
+++ b/providers/account.rb
@@ -125,7 +125,8 @@ def user_resource(exec_action)
     shell     my_shell              if my_shell
     password  new_resource.password if new_resource.password
     system    new_resource.system_user # ~FC048: Prefer Mixlib::ShellOut
-    supports  :manage_home => manage_home, :non_unique => non_unique
+    non_unique non_unique
+    manage_home true
     action    :nothing
   end
   r.run_action(exec_action)

--- a/test/cookbooks/user_test/recipes/lwrp.rb
+++ b/test/cookbooks/user_test/recipes/lwrp.rb
@@ -30,7 +30,7 @@ test_user = 'leia'
 test_user_home = "/home/#{test_user}"
 
 user test_user do
-  supports :manage_home => true
+  manage_home true
   home test_user_home
 end
 


### PR DESCRIPTION
This is to remove the following deprecation warnings related to Chef 13: 

```
Deprecated features used!
         method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"]) at 1 location:
           - /tmp/kitchen/cache/cookbooks/user/attributes/default.rb:22:in `from_file'
         supports { manage_home: true } on the user resource is deprecated and will be removed in Chef 13, set manage_home: true instead at 2 locations:
           - /tmp/kitchen/cache/cookbooks/user_test/recipes/lwrp.rb:33:in `block in from_file'
           - /tmp/kitchen/cache/cookbooks/user/providers/account.rb:128:in `block in user_resource'
         supports { non_unique: false } on the user resource is deprecated and will be removed in Chef 13, set non_unique: false instead at 1 location:
           - /tmp/kitchen/cache/cookbooks/user/providers/account.rb:128:in `block in user_resource'
```