### PR TITLE
kitchen.yml: use newer configuration syntax; update distributions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,25 +1,39 @@
 ---
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  data_bags_path: test/integration/data_bags
+  require_chef_omnibus: 12.1.2
 
 platforms:
-- name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-- name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
-- name: centos-6.4
-  driver_config:
-    box: opscode-centos-6.4
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-- name: centos-5.9
-  driver_config:
-    box: opscode-centos-5.9
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
+  - name: ubuntu-16.04 # XXX(theckman): EOL 2021/04
+    driver:
+      box: opscode_ubuntu-16.04
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-16.04_chef-provisionerless.box
+  - name: ubuntu-14.04 # XXX(theckman): EOL 2019/04
+    driver:
+      box: opscode_ubuntu-14.04
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+  - name: ubuntu-12.04 # XXX(theckman): EOL 2017/04
+    driver:
+      box: opscode_ubuntu-12.04
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+  - name: centos-7.x # XXX(theckman): EOL 2024/06/30
+    driver:
+      box: opscode_centos-7.2
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.2_chef-provisionerless.box
+  - name: centos-6.x # XXX(theckman): EOL 2020/11/30
+    driver:
+      box: opscode_centos-6.8
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.8_chef-provisionerless.box
+  - name: centos-5.x # XXX(theckman): EOL 2017/03/31
+    # XXX(theckman): for some reason CentOS 5.11 doesn't work in VirtualBox on my system.
+    # The VirtualBox instance enters Guru Meditation mode :(
+    driver:
+      box: opscode_centos-5.9
+      box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
 
 suites:
 - name: lwrp


### PR DESCRIPTION
This change to the `.kitchen.yml` file mostly updates the syntax for the newer
versions of Test Kitchen. In addition to that change, the following improvements
were made:

* pin the `chef-client` version to `12.1.2` to make sure we don't break
  compatibility.
* update all distributions to use the latest versions (except CentOS 5.x)