### PR TITLE
fix typo in account.rb comment introduced in 7d445eda

### DIFF
--- a/providers/account.rb
+++ b/providers/account.rb
@@ -97,7 +97,7 @@ def normalize_bool(val)
 end
 
 def user_gid
-  # this check is needed as the new user won't exit yet
+  # this check is needed as the new user won't exist yet,
   # in why_run mode, causing an uncaught ArgumentError exception
   Etc.getpwnam(new_resource.username).gid
 rescue ArgumentError


### PR DESCRIPTION
Nico Kadel-Garcia reported this typo in #89 (7d445eda) and it was merged-in
before it could be fixed.

This finally gets around to fixing the issue only 537 days later. :( Sorry it
took so long Nico, and thank you for the earlier review.

@nkadel-skyhook